### PR TITLE
Add time to LatestWalkDashboard

### DIFF
--- a/components/stats/LatestWalkDashboard/LatestWalkDashboard.tsx
+++ b/components/stats/LatestWalkDashboard/LatestWalkDashboard.tsx
@@ -1,6 +1,7 @@
 import { WalkSession } from '@/types/walk';
 import { formatDuration } from '@/utils/formatDuration';
 import StatCard from '@/components/stats/StatCard';
+import { formatDateTimeUTCToHelsinki } from '@/utils/formatDateTime';
 
 type Props = {
   session: WalkSession | null;
@@ -11,15 +12,9 @@ export default function LatestWalkDashboard({ session }: Props) {
   // If no sessions in database return this
   if (!session) return <p>No walk sessions yet.</p>;
 
-  const formattedDate = new Date(session.date).toLocaleDateString('fi-FI', {
-    day: '2-digit',
-    month: '2-digit',
-    year: 'numeric',
-  });
-
   return (
     <section className="stats-grid max-w-md mx-auto">
-      <StatCard label="Date" value={formattedDate} />
+      <StatCard label="Created At" value={formatDateTimeUTCToHelsinki(session.createdAt)} />
       <StatCard label="Duration" value={formatDuration(session.durationSec)} />
       <StatCard label="Distance" value={`${session.distanceKm} km`} />
       <StatCard label="Steps" value={session.steps} />

--- a/utils/formatDateTime.ts
+++ b/utils/formatDateTime.ts
@@ -1,0 +1,12 @@
+export function formatDateTimeUTCToHelsinki(dateTime: string | null): string {
+  if (!dateTime) return '-';
+
+  return new Date(dateTime.replace(' ', 'T') + 'Z').toLocaleString('fi-FI', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: 'Europe/Helsinki',
+  });
+}


### PR DESCRIPTION
Closes #29

Created new file in utils folder formatDateTime.ts to format time from UTC to Helsinki/Finland time. Example 09:07 UTC is now shown as 11:07 since we have winter time at Finland now.

Modified LatestWalkDashboard to use StatCard with label Created At with the value from formated time.