### PR TITLE
Add last week comparison to Current Week Stats

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,4 @@
-import { getAllWalkSessions, getWalkStats, getWalkStatsCurrentWeek, getLatestWalkSession } from "@/db/queries";
+import { getAllWalkSessions, getWalkStats, getWalkStatsCurrentWeek, getLatestWalkSession, getWalkStatsLastWeek } from "@/db/queries";
 import AddWalkForm from "@/components/walk/AddWalkForm";
 // import WalkStatsChart from "@/components/charts/WalkStatsChart";
 import TotalStatsDashboard from "@/components/stats/TotalStatsDashboard/TotalStatsDashboard";
@@ -18,6 +18,7 @@ export default async function Home() {
 
   const lastSessions = await getLatestWalkSession();
   const currentWeekStats = await getWalkStatsCurrentWeek();
+  const lastWeekStats = await getWalkStatsLastWeek();
 
   return (
     <main className="min-h-screen flex flex-col items-center justify-start p-8 bg-gray-50 dark:bg-gray-900">
@@ -34,7 +35,7 @@ export default async function Home() {
       <h2 className="text-2xl font-bold mb-4">Latest Walk Stats</h2>
       <LatestWalkDashboard session={lastSessions} />
       <h2 className="text-2xl font-bold mb-4">Current Week Stats</h2>
-      <CurrentWeekStatsDashboard stats={currentWeekStats} />
+      <CurrentWeekStatsDashboard currentWeek={currentWeekStats} lastWeek={lastWeekStats} />
     </main>
   );
 }

--- a/components/stats/CurrentWeekStatsDashboard/CurrentWeekStatsDashboard.tsx
+++ b/components/stats/CurrentWeekStatsDashboard/CurrentWeekStatsDashboard.tsx
@@ -1,14 +1,14 @@
 import { WalkTotals } from '@/types/walk';
-import { formatDuration } from '@/utils/formatDuration';
-import StatCard from '@/components/stats/StatCard';
+import { formatDuration, diffTime } from '@/utils/formatDuration';
+import StatCardWithDiff from '../StatCardWithDiff';
 
 type Props = {
-  stats: WalkTotals | null;
+  currentWeek: WalkTotals | null;
+  lastWeek: WalkTotals | null;
 };
 
-export default function CurrentWeekStatsDashboard({ stats }: Props) {
-  // If no sessions in current week
-  if (!stats || stats.totalSessions === 0) {
+export default function CurrentWeekStatsDashboard({ currentWeek, lastWeek }: Props) {
+  if (!currentWeek || currentWeek.totalSessions === 0) {
     return (
       <p className="text-center text-gray-500">
         No walk sessions recorded this week.
@@ -16,13 +16,38 @@ export default function CurrentWeekStatsDashboard({ stats }: Props) {
     );
   }
 
+  const diff = (current: number, last?: number, decimals = 0) =>
+  last !== undefined && last !== null
+    ? Number((current - last).toFixed(decimals))
+    : undefined;
+
   return (
     <section className="stats-grid">
-      <StatCard label="Total Sessions" value={stats.totalSessions} />
-      <StatCard label="Total Distance" value={`${stats.totalDistanceKm} km`} />
-      <StatCard label="Total Steps" value={stats.totalSteps} />
-      <StatCard label="Total Time" value={formatDuration(stats.totalDurationSec)} />
-      <StatCard label="Total Calories" value={stats.totalCalories ?? '-'} />
+      <StatCardWithDiff
+        label="Total Sessions"
+        value={currentWeek.totalSessions}
+        diff={diff(currentWeek.totalSessions, lastWeek?.totalSessions)}
+      />
+      <StatCardWithDiff
+        label="Total Distance"
+        value={`${currentWeek.totalDistanceKm} km`}
+        diff={diff(currentWeek.totalDistanceKm, lastWeek?.totalDistanceKm, 2)}
+      />
+      <StatCardWithDiff
+        label="Total Steps"
+        value={currentWeek.totalSteps}
+        diff={diff(currentWeek.totalSteps, lastWeek?.totalSteps)}
+      />
+      <StatCardWithDiff
+        label="Total Time"
+        value={formatDuration(currentWeek.totalDurationSec)}
+        diff={diffTime(currentWeek.totalDurationSec, lastWeek?.totalDurationSec)}
+      />
+      <StatCardWithDiff
+        label="Total Calories"
+        value={currentWeek.totalCalories ?? '-'}
+        diff={diff(currentWeek.totalCalories ?? 0, lastWeek?.totalCalories)}
+      />
     </section>
   );
 }

--- a/components/stats/StatCardWithDiff.tsx
+++ b/components/stats/StatCardWithDiff.tsx
@@ -1,0 +1,31 @@
+type StatCardWithDiffProps = {
+  label: string;
+  value: string | number;
+  diff?: number | string;
+};
+
+export default function StatCardWithDiff({ label, value, diff }: StatCardWithDiffProps) {
+  let isPositive = true;
+
+  if (typeof diff === 'number') {
+    isPositive = diff >= 0;
+  } else if (typeof diff === 'string') {
+    // Optional: parse number from string if it starts with + or - or contains numbers
+    const numericPart = parseFloat(diff.replace(/[^\d.-]/g, ''));
+    if (!isNaN(numericPart)) {
+      isPositive = numericPart >= 0;
+    }
+  }
+
+  return (
+    <div className="p-4 bg-white rounded shadow text-center">
+      <p className="text-sm text-gray-500">{label}</p>
+      <p className="text-2xl font-bold">{value}</p>
+      {diff !== undefined && (
+        <p className={`text-sm font-semibold ${isPositive ? 'text-green-600' : 'text-red-600'}`}>
+          {diff}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/types/walk.ts
+++ b/types/walk.ts
@@ -32,3 +32,11 @@ export type WalkTotalsCurrentWeek = {
   totalSteps: number
   totalCalories: number
 }
+
+export type WalkTotalsLastWeek = {
+  totalSessions: number;
+  totalDurationSec: number;
+  totalDistanceKm: number;
+  totalSteps: number;
+  totalCalories: number;
+};

--- a/utils/formatDuration.ts
+++ b/utils/formatDuration.ts
@@ -9,3 +9,11 @@ export function formatDuration(totalSeconds: number): string {
 
   return `${minutes} min`
 }
+
+export function diffTime(current: number, last?: number): string | undefined {
+  if (last === undefined || last === null) return undefined;
+
+  const difference = current - last;
+  const sign = difference >= 0 ? '+' : '-';
+  return sign + ' ' + formatDuration(Math.abs(difference));
+}

--- a/utils/getLastWeek.ts
+++ b/utils/getLastWeek.ts
@@ -1,0 +1,15 @@
+export function getLastWeekDates(): { startOfWeek: string; endOfWeek: string } {
+  const today = new Date();
+  const day = today.getDay(); // Sunday = 0, Monday = 1
+  const diffToMonday = day === 0 ? 6 : day - 1;
+  const lastMonday = new Date(today);
+  lastMonday.setDate(today.getDate() - diffToMonday - 7);
+
+  const lastSunday = new Date(lastMonday);
+  lastSunday.setDate(lastMonday.getDate() + 6);
+
+  const startOfWeek = lastMonday.toISOString().split('T')[0];
+  const endOfWeek = lastSunday.toISOString().split('T')[0];
+
+  return { startOfWeek, endOfWeek };
+}


### PR DESCRIPTION
Closes #34

- Added `StatCardWithDiff` to show stats with differences from last week (green = +, red = -).

- New query `getWalkStatsLastWeek` and type `WalkTotalsLastWeek` to fetch last week totals.

- Utility `getLastWeekDates` for last week start/end and `diffTime` for formatted time differences.

- Updated `CurrentWeekStatsDashboard` to use `StatCardWithDiff` and display weekly comparisons.

- Page integration now fetches last week stats and passes them to the dashboard.