### PR TITLE
Refactor stat diffs and adjust UI styles

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,24 +3,26 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  color-scheme: light;
 }
 
-@theme inline {
+/* @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-}
+} */
 
-@media (prefers-color-scheme: dark) {
+/* @media (prefers-color-scheme: dark) {
   :root {
     --background: #0a0a0a;
     --foreground: #ededed;
   }
-}
+} */
 
 body {
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+  color-scheme: light;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -30,10 +30,10 @@ export default async function Home() {
   const dailyTotals = await getWalkDailyTotals(startDate, endDate);
 
   return (
-    <main className="min-h-screen flex flex-col items-center justify-start p-8 bg-gray-50 dark:bg-gray-900">
+    <main className="min-h-screen flex flex-col items-center justify-start p-8 bg-gray-300">
       <h1 className="text-3xl font-bold text-blue-600 mb-6">All Walk Sessions (Test)</h1>
 
-      <pre className="w-full max-w-4xl p-4 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 rounded-lg shadow overflow-x-auto">
+      <pre className="w-full max-w-4xl p-4 bg-white text-gray-900 rounded-lg shadow overflow-x-auto">
         {JSON.stringify(totalStats, null, 2)}
       </pre>
 

--- a/components/stats/CurrentWeekStatsDashboard/CurrentWeekStatsDashboard.tsx
+++ b/components/stats/CurrentWeekStatsDashboard/CurrentWeekStatsDashboard.tsx
@@ -1,5 +1,5 @@
 import { WalkTotalsCurrentWeek } from '@/types/walk';
-import { formatDuration, diffTime } from '@/utils/formatDuration';
+import { formatDuration } from '@/utils/formatDuration';
 import StatCardWithDiff from '../StatCardWithDiff';
 
 type Props = {
@@ -8,6 +8,13 @@ type Props = {
 };
 
 export default function CurrentWeekStatsDashboard({ currentWeek, lastWeek }: Props) {
+  type DiffDirection = 'up' | 'down' | 'same';
+  type DiffResult = {
+    label: string;
+    descriptor: string;
+    direction: DiffDirection;
+  };
+
   const emptyTotals: WalkTotalsCurrentWeek = {
     totalSessions: 0,
     totalDurationSec: 0,
@@ -18,37 +25,101 @@ export default function CurrentWeekStatsDashboard({ currentWeek, lastWeek }: Pro
 
   const current = currentWeek ?? emptyTotals;
 
-  const diff = (value: number, last?: number, decimals = 0) =>
-    last !== undefined && last !== null
-      ? Number((value - last).toFixed(decimals))
-      : undefined;
+  const buildDiff = (
+    value: number,
+    last?: number,
+    options?: {
+      decimals?: number;
+      percentDecimals?: number;
+      unit?: string;
+      format?: (value: number) => string;
+    }
+  ): DiffResult | undefined => {
+    if (last === undefined || last === null) return undefined;
+
+    const decimals = options?.decimals ?? 0;
+    const percentDecimals = options?.percentDecimals ?? 0;
+    const difference = Number((value - last).toFixed(decimals));
+    const direction: DiffDirection =
+      difference > 0 ? 'up' : difference < 0 ? 'down' : 'same';
+    const arrow = direction === 'up' ? '↑' : direction === 'down' ? '↓' : '→';
+    const sign = difference >= 0 ? '+' : '-';
+    const absDiff = Math.abs(difference);
+    const absText = options?.format
+      ? options.format(absDiff)
+      : `${absDiff.toFixed(decimals)}${options?.unit ? ` ${options.unit}` : ''}`;
+
+    const percent = last === 0 ? undefined : Math.abs((difference / last) * 100);
+    const percentText =
+      percent !== undefined
+        ? ` (${sign}${percent.toFixed(percentDecimals)}%)`
+        : '';
+
+    const label = `${arrow} ${absText}${percentText}`;
+    const descriptor =
+      direction === 'up'
+        ? 'More than last week'
+        : direction === 'down'
+          ? 'Less than last week'
+          : 'Same as last week';
+
+    return { label, descriptor, direction };
+  };
+
+  const sessionsDiff = buildDiff(current.totalSessions, lastWeek?.totalSessions, {
+    unit: 'sessions',
+  });
+  const distanceDiff = buildDiff(current.totalDistanceKm, lastWeek?.totalDistanceKm, {
+    unit: 'km',
+    decimals: 2,
+    percentDecimals: 1,
+  });
+  const stepsDiff = buildDiff(current.totalSteps, lastWeek?.totalSteps, {
+    unit: 'steps',
+  });
+  const timeDiff = buildDiff(current.totalDurationSec, lastWeek?.totalDurationSec, {
+    format: (value) => formatDuration(value),
+  });
+  const caloriesDiff = buildDiff(current.totalCalories, lastWeek?.totalCalories, {
+    unit: 'calories',
+  });
 
   return (
     <section className="stats-grid">
       <StatCardWithDiff
         label="Total Sessions"
         value={current.totalSessions}
-        diff={diff(current.totalSessions, lastWeek?.totalSessions)}
+        diffLabel={sessionsDiff?.label}
+        diffDescriptor={sessionsDiff?.descriptor}
+        diffDirection={sessionsDiff?.direction}
       />
       <StatCardWithDiff
         label="Total Distance"
         value={`${current.totalDistanceKm} km`}
-        diff={diff(current.totalDistanceKm, lastWeek?.totalDistanceKm, 2)}
+        diffLabel={distanceDiff?.label}
+        diffDescriptor={distanceDiff?.descriptor}
+        diffDirection={distanceDiff?.direction}
       />
       <StatCardWithDiff
         label="Total Steps"
         value={current.totalSteps}
-        diff={diff(current.totalSteps, lastWeek?.totalSteps)}
+        diffLabel={stepsDiff?.label}
+        diffDescriptor={stepsDiff?.descriptor}
+        diffDirection={stepsDiff?.direction}
       />
       <StatCardWithDiff
         label="Total Time"
         value={formatDuration(current.totalDurationSec)}
-        diff={diffTime(current.totalDurationSec, lastWeek?.totalDurationSec)}
+        diffLabel={timeDiff?.label}
+        diffDescriptor={timeDiff?.descriptor}
+        diffDirection={timeDiff?.direction}
       />
       <StatCardWithDiff
         label="Total Calories"
         value={current.totalCalories}
-        diff={diff(current.totalCalories, lastWeek?.totalCalories)}
+        diffLabel={caloriesDiff?.label}
+        diffDescriptor={caloriesDiff?.descriptor}
+        diffDirection={caloriesDiff?.direction}
       />
     </section>
   );

--- a/components/stats/StatCard.tsx
+++ b/components/stats/StatCard.tsx
@@ -5,8 +5,8 @@ type StatCardProps = {
 
 export default function StatCard({ label, value }: StatCardProps) {
   return (
-    <div className="p-4 bg-white rounded shadow text-center">
-      <p className="text-sm text-gray-500">{label}</p>
+    <div className="p-4 m-1 bg-white rounded shadow text-center">
+      <p className="text-sm">{label}</p>
       <p className="text-2xl font-bold">{value}</p>
     </div>
   )

--- a/components/stats/StatCardWithDiff.tsx
+++ b/components/stats/StatCardWithDiff.tsx
@@ -1,30 +1,34 @@
 type StatCardWithDiffProps = {
   label: string;
   value: string | number;
-  diff?: number | string;
+  diffLabel?: string;
+  diffDescriptor?: string;
+  diffDirection?: 'up' | 'down' | 'same';
 };
 
-export default function StatCardWithDiff({ label, value, diff }: StatCardWithDiffProps) {
-  let isPositive = true;
-
-  if (typeof diff === 'number') {
-    isPositive = diff >= 0;
-  } else if (typeof diff === 'string') {
-    // Optional: parse number from string if it starts with + or - or contains numbers
-    const numericPart = parseFloat(diff.replace(/[^\d.-]/g, ''));
-    if (!isNaN(numericPart)) {
-      isPositive = numericPart >= 0;
-    }
-  }
+export default function StatCardWithDiff({
+  label,
+  value,
+  diffLabel,
+  diffDescriptor,
+  diffDirection,
+}: StatCardWithDiffProps) {
+  const diffColorClass =
+    diffDirection === 'up'
+      ? 'text-green-600'
+      : diffDirection === 'down'
+        ? 'text-red-600'
+        : 'text-gray-500';
 
   return (
-    <div className="p-4 bg-white rounded shadow text-center">
-      <p className="text-sm text-gray-500">{label}</p>
+    <div className="p-4 m-1 bg-white rounded shadow text-center">
+      <p className="text-sm">{label}</p>
       <p className="text-2xl font-bold">{value}</p>
-      {diff !== undefined && (
-        <p className={`text-sm font-semibold ${isPositive ? 'text-green-600' : 'text-red-600'}`}>
-          {diff}
-        </p>
+      {diffLabel && (
+        <p className={`text-sm font-semibold ${diffColorClass}`}>{diffLabel}</p>
+      )}
+      {diffDescriptor && (
+        <p className="text-xs text-gray-500">{diffDescriptor}</p>
       )}
     </div>
   );

--- a/components/walk/AddWalkForm.tsx
+++ b/components/walk/AddWalkForm.tsx
@@ -69,7 +69,7 @@ export default function AddWalkForm() {
   return (
     <form
       onSubmit={handleSubmit}
-      className="max-w-md space-y-4 rounded-lg border p-4"
+      className="max-w-md space-y-4 rounded-lg border p-4 bg-white"
     >
       <h2 className="text-lg font-semibold">Add Walk Session</h2>
 


### PR DESCRIPTION
Closes #39

- Add diffLabel, diffDescriptor, and diffDirection props to carry preformatted diff text and direction. See StatCardWithDiff.tsx. 
- Compute diffColorClass from diffDirection (up → green, down → red, same → gray) to color the diff line. See StatCardWithDiff.tsx. 
- Conditionally render the diff label and descriptor blocks only when provided, keeping layout clean. See StatCardWithDiff.tsx. 
- Present the diff label in emphasized text and the descriptor in smaller muted text for visual hierarchy. See StatCardWithDiff.tsx.

- Also took dark mode off, and made small Tailwind enhancements.