### PR TITLE
Add server action for journey progress

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -1,10 +1,58 @@
 'use server'
 
-import { createWalkSession } from '@/db/queries'
+import { createWalkSession, getAllGoalsOrdered, getAllWalkSessions } from '@/db/queries'
+import { JourneyProgress, Goal } from '@/types/goals'
 import { NewWalkSession } from '@/types/walk'
+import { computeJourneyProgress, computeTotalWalkedKm } from '@/utils/journeyProgress'
 import { refresh } from 'next/cache'
 
 export async function addWalkSessionAction(data: NewWalkSession) {
   await createWalkSession(data)
   refresh()
+}
+
+function createEmptyJourneyProgress(totalKm: number): JourneyProgress {
+  return {
+    totalKm,
+    currentLeg: null,
+    progressPercent: 0,
+    remainingKm: 0,
+    legs: [],
+  }
+}
+
+// Server action that returns UI-friendly journey progress data.
+export async function getJourneyProgressAction(): Promise<JourneyProgress> {
+  try {
+    const [sessions, goalRows] = await Promise.all([
+      getAllWalkSessions(),
+      getAllGoalsOrdered(),
+    ])
+
+    const totalKm = computeTotalWalkedKm(
+      sessions.map((session) => ({ distanceKm: session.distanceKm }))
+    )
+
+    if (goalRows.length === 0) {
+      return createEmptyJourneyProgress(totalKm)
+    }
+
+    const goals: Goal[] = goalRows.map((row) => ({
+      id: row.id,
+      orderIndex: row.orderIndex,
+      name: row.name,
+      startCity: row.startCity,
+      endCity: row.endCity,
+      startLat: row.startLat,
+      startLng: row.startLng,
+      endLat: row.endLat,
+      endLng: row.endLng,
+      segmentKm: row.segmentKm,
+    }))
+
+    return computeJourneyProgress(goals, totalKm)
+  } catch (err) {
+    console.error('Failed to build journey progress:', err)
+    return createEmptyJourneyProgress(0)
+  }
 }

--- a/db/queries.ts
+++ b/db/queries.ts
@@ -1,6 +1,6 @@
 import { sql, desc } from 'drizzle-orm'
 import { db } from './client'
-import { walkSessions } from './schema'
+import { goals, walkSessions } from './schema'
 import { DistanceTrendPoint, NewWalkSession, WalkDailyTotal, WalkTotals, WalkSession, WalkTotalsCurrentWeek, WalkTotalsLastWeek } from '@/types/walk'
 import { getCurrentWeek } from '@/utils/getCurrentWeek'
 import { getLastWeekDates } from '@/utils/getLastWeek'
@@ -13,6 +13,16 @@ export async function getAllWalkSessions() {
     return await db.select().from(walkSessions)
   } catch (err) {
     console.error('Failed to fetch walk sessions:', err)
+    return []
+  }
+}
+
+// Fetch all goals ordered by route sequence
+export async function getAllGoalsOrdered() {
+  try {
+    return await db.select().from(goals).orderBy(goals.orderIndex)
+  } catch (err) {
+    console.error('Failed to fetch goals:', err)
     return []
   }
 }


### PR DESCRIPTION
Closes #47

Exposes journey progress data via a server action for UI consumption.

- Added ordered goals query in queries.ts
- Added getJourneyProgressAction() in actions.ts to fetch sessions + goals, compute totals, and return UI-ready progress data 
- Handles empty/error cases with safe defaults