### PR TITLE
JourneyTimeline/map goal anchors

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ import DistanceTrendChart from "@/components/charts/DistanceTrendChart";
 import TotalStatsDashboard from "@/components/stats/TotalStatsDashboard/TotalStatsDashboard";
 import LatestWalkDashboard from "@/components/stats/LatestWalkDashboard/LatestWalkDashboard";
 import CurrentWeekStatsDashboard from "@/components/stats/CurrentWeekStatsDashboard/CurrentWeekStatsDashboard";
-import { JourneyDashboard, JourneyMap } from "@/components/journey";
+import { JourneySection } from "@/components/journey";
 
 export default async function Home() {
   // const allSessions = await getAllWalkSessions ()
@@ -46,10 +46,7 @@ export default async function Home() {
       <AddWalkForm />
       <section className="w-full max-w-6xl">
         <h2 className="text-2xl font-bold mb-4">Journey Progress</h2>
-        <div className="grid gap-6 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
-          <JourneyDashboard progress={journeyProgress} />
-          <JourneyMap progress={journeyProgress} />
-        </div>
+        <JourneySection progress={journeyProgress} />
       </section>
       {/* <WalkStatsChart stats={totalStats} /> */}
       <WalkHeatmapChart

--- a/components/journey/JourneyDashboard.tsx
+++ b/components/journey/JourneyDashboard.tsx
@@ -5,13 +5,25 @@ import { JourneyProgress } from '@/types/goals'
 type JourneyDashboardProps = {
   progress: JourneyProgress | null
   isLoading?: boolean
+  selectedLegId?: number | null
+  onSelectLegId?: (legId: number | null) => void
 }
 
-export default function JourneyDashboard({ progress, isLoading = false }: JourneyDashboardProps) {
+export default function JourneyDashboard({
+  progress,
+  isLoading = false,
+  selectedLegId,
+  onSelectLegId,
+}: JourneyDashboardProps) {
   return (
     <section className="w-full grid gap-6">
       <ProgressCard progress={progress} isLoading={isLoading} />
-      <JourneyTimeline legs={progress?.legs ?? []} isLoading={isLoading} />
+      <JourneyTimeline
+        legs={progress?.legs ?? []}
+        isLoading={isLoading}
+        selectedLegId={selectedLegId}
+        onSelectLegId={onSelectLegId}
+      />
     </section>
   )
 }

--- a/components/journey/JourneyMap.tsx
+++ b/components/journey/JourneyMap.tsx
@@ -1,6 +1,6 @@
  'use client'
 
-import { JourneyProgress } from '@/types/goals'
+import { JourneyLegProgress, JourneyProgress } from '@/types/goals'
 import dynamic from 'next/dynamic'
 
 const JourneyMapClient = dynamic(() => import('./JourneyMapClient'), {
@@ -9,8 +9,9 @@ const JourneyMapClient = dynamic(() => import('./JourneyMapClient'), {
 
 type JourneyMapProps = {
   progress: JourneyProgress | null
+  selectedLeg?: JourneyLegProgress | null
 }
 
-export default function JourneyMap({ progress }: JourneyMapProps) {
-  return <JourneyMapClient progress={progress} />
+export default function JourneyMap({ progress, selectedLeg = null }: JourneyMapProps) {
+  return <JourneyMapClient progress={progress} selectedLeg={selectedLeg} />
 }

--- a/components/journey/JourneyMapClient.tsx
+++ b/components/journey/JourneyMapClient.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { useMemo } from 'react'
-import { MapContainer, Marker, Polyline, TileLayer } from 'react-leaflet'
+import { useEffect, useMemo } from 'react'
+import { MapContainer, Marker, Polyline, TileLayer, useMap } from 'react-leaflet'
 import L from 'leaflet'
-import { JourneyProgress } from '@/types/goals'
+import { JourneyLegProgress, JourneyProgress } from '@/types/goals'
 import { computeCurrentPosition } from '@/utils/journeyMap'
 
 // Fix default Leaflet marker icons when bundling with Next.js.
@@ -21,9 +21,36 @@ L.Marker.prototype.options.icon = defaultIcon
 
 type JourneyMapClientProps = {
   progress: JourneyProgress | null
+  selectedLeg?: JourneyLegProgress | null
 }
 
-export default function JourneyMapClient({ progress }: JourneyMapClientProps) {
+type MapFocusProps = {
+  selectedLeg: JourneyLegProgress | null
+  currentPosition: { lat: number; lng: number } | null
+}
+
+function MapFocus({ selectedLeg, currentPosition }: MapFocusProps) {
+  const map = useMap()
+
+  useEffect(() => {
+    if (selectedLeg) {
+      const bounds = L.latLngBounds(
+        [selectedLeg.goal.startLat, selectedLeg.goal.startLng],
+        [selectedLeg.goal.endLat, selectedLeg.goal.endLng]
+      )
+      map.fitBounds(bounds, { padding: [40, 40] })
+      return
+    }
+
+    if (currentPosition) {
+      map.setView([currentPosition.lat, currentPosition.lng], 8)
+    }
+  }, [map, selectedLeg, currentPosition])
+
+  return null
+}
+
+export default function JourneyMapClient({ progress, selectedLeg = null }: JourneyMapClientProps) {
   const legs = useMemo(() => progress?.legs ?? [], [progress?.legs])
 
   const routePositions = useMemo(() => {
@@ -64,6 +91,13 @@ export default function JourneyMapClient({ progress }: JourneyMapClientProps) {
     ? [currentPosition.lat, currentPosition.lng]
     : routePositions[0] ?? [0, 0]
 
+  const selectedStart: [number, number] | null = selectedLeg
+    ? [selectedLeg.goal.startLat, selectedLeg.goal.startLng]
+    : null
+  const selectedEnd: [number, number] | null = selectedLeg
+    ? [selectedLeg.goal.endLat, selectedLeg.goal.endLng]
+    : null
+
   return (
     <section className="w-full h-full rounded-2xl bg-white p-3 shadow-md border border-slate-200">
       <MapContainer
@@ -72,6 +106,7 @@ export default function JourneyMapClient({ progress }: JourneyMapClientProps) {
         scrollWheelZoom={false}
         className="h-72 w-full rounded-xl sm:h-80 lg:h-full"
       >
+        <MapFocus selectedLeg={selectedLeg} currentPosition={currentPosition} />
         <TileLayer
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
@@ -79,6 +114,8 @@ export default function JourneyMapClient({ progress }: JourneyMapClientProps) {
         {routePositions.length > 1 && (
           <Polyline positions={routePositions} pathOptions={{ color: '#0F52BA', weight: 4 }} />
         )}
+        {selectedStart && <Marker position={selectedStart} />}
+        {selectedEnd && <Marker position={selectedEnd} />}
         {currentPosition && (
           <Marker position={[currentPosition.lat, currentPosition.lng]} />
         )}

--- a/components/journey/JourneySection.tsx
+++ b/components/journey/JourneySection.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import JourneyDashboard from './JourneyDashboard'
+import JourneyMap from './JourneyMap'
+import { JourneyLegProgress, JourneyProgress } from '@/types/goals'
+
+type JourneySectionProps = {
+  progress: JourneyProgress | null
+}
+
+export default function JourneySection({ progress }: JourneySectionProps) {
+  const legs = useMemo(() => progress?.legs ?? [], [progress?.legs])
+  const [selectedLegId, setSelectedLegId] = useState<number | null>(null)
+
+  const selectedLeg = useMemo<JourneyLegProgress | null>(() => {
+    if (selectedLegId === null) return null
+    return legs.find((leg) => leg.goal.id === selectedLegId) ?? null
+  }, [legs, selectedLegId])
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+      <JourneyDashboard
+        progress={progress}
+        selectedLegId={selectedLegId}
+        onSelectLegId={setSelectedLegId}
+      />
+      <JourneyMap progress={progress} selectedLeg={selectedLeg} />
+    </div>
+  )
+}

--- a/components/journey/JourneyTimeline.tsx
+++ b/components/journey/JourneyTimeline.tsx
@@ -6,6 +6,8 @@ import { JourneyLegProgress } from '@/types/goals'
 type JourneyTimelineProps = {
   legs: JourneyLegProgress[]
   isLoading?: boolean
+  selectedLegId?: number | null
+  onSelectLegId?: (legId: number | null) => void
 }
 
 function formatKm(value: number, fractionDigits = 0): string {
@@ -13,7 +15,12 @@ function formatKm(value: number, fractionDigits = 0): string {
   return safeValue.toFixed(fractionDigits)
 }
 
-export default function JourneyTimeline({ legs, isLoading = false }: JourneyTimelineProps) {
+export default function JourneyTimeline({
+  legs,
+  isLoading = false,
+  selectedLegId = null,
+  onSelectLegId,
+}: JourneyTimelineProps) {
   const baseWindowSize = 5
 
   const initialWindow = useMemo(() => {
@@ -72,6 +79,7 @@ export default function JourneyTimeline({ legs, isLoading = false }: JourneyTime
         {visibleLegs.map((leg) => {
           const isCompleted = leg.status === 'completed'
           const isCurrent = leg.status === 'current'
+          const isSelected = selectedLegId === leg.goal.id
           const dotClass = isCompleted
             ? 'bg-emerald-500'
             : isCurrent
@@ -82,19 +90,29 @@ export default function JourneyTimeline({ legs, isLoading = false }: JourneyTime
             : isCurrent
               ? 'text-slate-900 font-medium'
               : 'text-slate-500'
+          const rowClass = isSelected
+            ? 'border-blue-200 bg-blue-50'
+            : 'border-transparent hover:bg-slate-50'
 
           return (
-            <li key={leg.goal.id} className="flex items-center justify-between">
-              <div className="flex items-center gap-3">
-                <span className={`h-2.5 w-2.5 rounded-full ${dotClass}`} aria-hidden="true" />
-                <div>
-                  <p className={`text-sm ${textClass}`}>
-                    {leg.goal.startCity} to {leg.goal.endCity}
-                  </p>
-                  <p className="text-xs text-slate-500">{leg.goal.name}</p>
+            <li key={leg.goal.id}>
+              <button
+                type="button"
+                onClick={() => onSelectLegId?.(isSelected ? null : leg.goal.id)}
+                aria-pressed={isSelected}
+                className={`flex w-full items-center justify-between rounded-lg border px-3 py-2 text-left transition ${rowClass}`}
+              >
+                <div className="flex items-center gap-3">
+                  <span className={`h-2.5 w-2.5 rounded-full ${dotClass}`} aria-hidden="true" />
+                  <div>
+                    <p className={`text-sm ${textClass}`}>
+                      {leg.goal.startCity} to {leg.goal.endCity}
+                    </p>
+                    <p className="text-xs text-slate-500">{leg.goal.name}</p>
+                  </div>
                 </div>
-              </div>
-              <span className="text-xs text-slate-500">{formatKm(leg.goal.segmentKm)} km</span>
+                <span className="text-xs text-slate-500">{formatKm(leg.goal.segmentKm)} km</span>
+              </button>
             </li>
           )
         })}

--- a/components/journey/index.ts
+++ b/components/journey/index.ts
@@ -1,5 +1,6 @@
 export { default as JourneyDashboard } from './JourneyDashboard'
 export { default as JourneyMap } from './JourneyMap'
+export { default as JourneySection } from './JourneySection'
 export { default as JourneyTimeline } from './JourneyTimeline'
 export { default as ProgressBar } from './ProgressBar'
 export { default as ProgressCard } from './ProgressCard'


### PR DESCRIPTION
Closes #58

- Added `selectedLegId` and `onSelectLegId` to `JourneyTimeline` so rows can be clicked and toggled
- Highlighted the selected row with a distinct border/background and `aria-pressed` state
- Introduced `JourneySection` to own selection state and pass it to both timeline and map
- Extended `JourneyMap` / `JourneyMapClient` to accept `selectedLeg` and render start/end markers
- Added `MapFocus` helper to fit map bounds to the selected leg (or return to current position when cleared)
- Updated Home page to use `JourneySection` instead of separately rendering `JourneyDashboard` + `JourneyMap`

Selecting a leg from the timeline should let users focus the map on that leg’s start/end anchors without losing context of the route.