### PR TITLE
Fix week/month date ranges for local time (Finland)

### DIFF
--- a/types/time.ts
+++ b/types/time.ts
@@ -1,0 +1,11 @@
+export type MonthRange = {
+  startDate: string
+  endDate: string
+  label: string
+}
+
+export type WeekRange = {
+  startDate: string
+  endDate: string
+  label: string
+}

--- a/utils/getCurrentWeek.ts
+++ b/utils/getCurrentWeek.ts
@@ -1,6 +1,20 @@
+/**
+ * Returns the start and end dates of the current week.
+ *
+ * @returns An object containing the start and end dates of the current week in YYYY-MM-DD format.
+ */
+
 export function getCurrentWeek(): { startOfWeek: string; endOfWeek: string } {
   const now = new Date();
-  const day = now.getDay(); // 0 = Sunday, 1 = Monday, ...
+  const day = now.getDay();
+
+  // Build YYYY-MM-DD using local time to avoid UTC date shifts.
+  const formatLocalDate = (date: Date): string => {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const dayOfMonth = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${dayOfMonth}`;
+  };
 
   // Calculate Monday of current week
   const diffToMonday = (day === 0 ? 6 : day - 1); // Sunday goes back 6 days
@@ -15,7 +29,7 @@ export function getCurrentWeek(): { startOfWeek: string; endOfWeek: string } {
 
   // Return as YYYY-MM-DD strings for Drizzle query
   return {
-    startOfWeek: monday.toISOString().split('T')[0],
-    endOfWeek: sunday.toISOString().split('T')[0],
+    startOfWeek: formatLocalDate(monday),
+    endOfWeek: formatLocalDate(sunday),
   };
 }

--- a/utils/getLastSixMonths.ts
+++ b/utils/getLastSixMonths.ts
@@ -1,7 +1,11 @@
-export type MonthRange = {
-  startDate: string
-  endDate: string
-  label: string
+import type { MonthRange } from '@/types/time'
+
+// Build YYYY-MM-DD using local time to avoid UTC date shifts.
+function formatLocalDate(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
 }
 
 function formatMonthLabel(date: Date): string {
@@ -28,8 +32,8 @@ export function getLastSixMonths(): MonthRange[] {
     const monthEnd = new Date(monthStart.getFullYear(), monthStart.getMonth() + 1, 0)
 
     months.push({
-      startDate: monthStart.toISOString().split('T')[0],
-      endDate: monthEnd.toISOString().split('T')[0],
+      startDate: formatLocalDate(monthStart),
+      endDate: formatLocalDate(monthEnd),
       label: formatMonthLabel(monthStart),
     })
   }

--- a/utils/getLastSixWeeks.ts
+++ b/utils/getLastSixWeeks.ts
@@ -1,7 +1,11 @@
-export type WeekRange = {
-  startDate: string
-  endDate: string
-  label: string
+import type { WeekRange } from '@/types/time'
+
+// Build YYYY-MM-DD using local time to avoid UTC date shifts.
+function formatLocalDate(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
 }
 
 function formatWeekLabel(start: Date, end: Date): string {
@@ -31,8 +35,8 @@ export function getLastSixWeeks(): WeekRange[] {
     endDate.setDate(startDate.getDate() + 6)
 
     weeks.push({
-      startDate: startDate.toISOString().split('T')[0],
-      endDate: endDate.toISOString().split('T')[0],
+      startDate: formatLocalDate(startDate),
+      endDate: formatLocalDate(endDate),
       label: formatWeekLabel(startDate, endDate),
     })
   }

--- a/utils/getLastWeek.ts
+++ b/utils/getLastWeek.ts
@@ -1,15 +1,29 @@
+/**
+ * Returns the start and end dates of the last week.
+ *
+ * @returns An object containing the start and end dates of the last week in YYYY-MM-DD format.
+ */
+
 export function getLastWeekDates(): { startOfWeek: string; endOfWeek: string } {
   const today = new Date();
   const day = today.getDay(); // Sunday = 0, Monday = 1
   const diffToMonday = day === 0 ? 6 : day - 1;
+
+  // Build YYYY-MM-DD using local time to avoid UTC date shifts.
+  const formatLocalDate = (date: Date): string => {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const dayOfMonth = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${dayOfMonth}`;
+  };
   const lastMonday = new Date(today);
   lastMonday.setDate(today.getDate() - diffToMonday - 7);
 
   const lastSunday = new Date(lastMonday);
   lastSunday.setDate(lastMonday.getDate() + 6);
 
-  const startOfWeek = lastMonday.toISOString().split('T')[0];
-  const endOfWeek = lastSunday.toISOString().split('T')[0];
+  const startOfWeek = formatLocalDate(lastMonday);
+  const endOfWeek = formatLocalDate(lastSunday);
 
   return { startOfWeek, endOfWeek };
 }


### PR DESCRIPTION
Close #67

- Build YYYY-MM-DD date strings in local time to avoid UTC day shifts.
- Apply the local date formatting in current week, last week, last six weeks, and last six months helpers.
- Centralize week/month range types in a shared time types file.